### PR TITLE
Fix SFML 2.0 compatibility

### DIFF
--- a/mym/source/events.cpp
+++ b/mym/source/events.cpp
@@ -33,18 +33,39 @@ namespace mym
 	void Events::CheckEvents ()
 	{
 		sf::Event event;
+#if SFML_VERSION_MAJOR < 2
 		while (m_window.GetEvent(event))
+#else
+		while (m_window.pollEvent(event))
+#endif
 		{
+#if SFML_VERSION_MAJOR < 2
 			switch (event.Type)
+#else
+			switch (event.type)
+#endif
 			{
 				case sf::Event::KeyPressed:
+#if SFML_VERSION_MAJOR < 2
 					AMeteor::_keypad.KeyPressed(event.Key.Code);
+#else
+					AMeteor::_keypad.KeyPressed(event.key.code);
+#endif
 					break;
 				case sf::Event::KeyReleased:
+#if SFML_VERSION_MAJOR < 2
 					AMeteor::_keypad.KeyReleased(event.Key.Code);
+#else
+					AMeteor::_keypad.KeyReleased(event.key.code);
+#endif
 					break;
+#if SFML_VERSION_MAJOR < 2
 				case sf::Event::JoyButtonPressed:
 					switch (event.JoyButton.Button)
+#else
+				case sf::Event::JoystickButtonPressed:
+					switch (event.joystickButton.button)
+#endif
 					{
 						// XXX
 						//case 7:
@@ -52,13 +73,23 @@ namespace mym
 						//	SOUND.SetSampleskip(SPDUP_SNDSKIP);
 						//	break;
 						default:
+#if SFML_VERSION_MAJOR < 2
 							AMeteor::_keypad.JoyButtonPressed(event.JoyButton.JoystickId,
 									event.JoyButton.Button);
+#else
+							AMeteor::_keypad.JoyButtonPressed(event.joystickButton.joystickId,
+									event.joystickButton.button);
+#endif
 							break;
 					}
 					break;
+#if SFML_VERSION_MAJOR < 2
 				case sf::Event::JoyButtonReleased:
 					switch (event.JoyButton.Button)
+#else
+				case sf::Event::JoystickButtonReleased:
+					switch (event.joystickButton.button)
+#endif
 					{
 						// XXX
 						//case 7:
@@ -66,14 +97,25 @@ namespace mym
 						//	SOUND.SetSampleskip(0);
 						//	break;
 						default:
+#if SFML_VERSION_MAJOR < 2
 							AMeteor::_keypad.JoyButtonReleased(event.JoyButton.JoystickId,
 									event.JoyButton.Button);
+#else
+							AMeteor::_keypad.JoyButtonReleased(event.joystickButton.joystickId,
+									event.joystickButton.button);
+#endif
 							break;
 					}
 					break;
+#if SFML_VERSION_MAJOR < 2
 				case sf::Event::JoyMoved:
 					AMeteor::_keypad.JoyMoved(event.JoyMove.JoystickId,
 							event.JoyMove.Axis, event.JoyMove.Position);
+#else
+				case sf::Event::JoystickMoved:
+					AMeteor::_keypad.JoyMoved(event.joystickMove.joystickId,
+							event.joystickMove.axis, event.joystickMove.position);
+#endif
 					break;
 				//case sf::Event::Resized:
 				//	LCD.EventResize(event.Size.Width, event.Size.Height);

--- a/mym/source/window.cpp
+++ b/mym/source/window.cpp
@@ -75,9 +75,17 @@ namespace mym
 		Uninit();
 
 		if (display)
+#if SFML_VERSION_MAJOR < 2
 			m_window.Create (display);
+#else
+			m_window.create (display);
+#endif
 		else
+#if SFML_VERSION_MAJOR < 2
 			m_window.Create (sf::VideoMode(4*240, 4*160, 32), "Meteor");
+#else
+			m_window.create (sf::VideoMode(4*240, 4*160, 32), "Meteor");
+#endif
 
 		InitGl();
 		StartThread();
@@ -98,7 +106,11 @@ namespace mym
 			0, 1,
 		};
 
+#if SFML_VERSION_MAJOR < 2
 		m_window.SetActive();
+#else
+		m_window.setActive();
+#endif
 
 		// TODO check (may be called multiple times)
 		if (GLEW_OK != glewInit())
@@ -129,8 +141,13 @@ namespace mym
 		glBufferData(GL_PIXEL_UNPACK_BUFFER, 4*240*4*160*4, NULL,
 				GL_DYNAMIC_DRAW);
 
+#if SFML_VERSION_MAJOR < 2
 		m_window.Display();
 		m_window.SetActive(false);
+#else
+		m_window.display();
+		m_window.setActive(false);
+#endif
 	}
 
 	void Window::StartThread()
@@ -160,13 +177,21 @@ namespace mym
 
 	void Window::UninitGl()
 	{
+#if SFML_VERSION_MAJOR < 2
 		if (m_window.SetActive())
+#else
+		if (m_window.setActive())
+#endif
 		{
 			glDeleteBuffers(1, &m_pbo);
 			glDeleteTextures(1, &m_texture);
 			glDeleteBuffers(1, &m_vbo);
 			m_vbo = m_texture = m_pbo = 0;
+#if SFML_VERSION_MAJOR < 2
 			m_window.Close();
+#else
+			m_window.close();
+#endif
 		}
 	}
 
@@ -195,7 +220,11 @@ namespace mym
 			sched_setaffinity(syscall(__NR_gettid), sizeof(set), &set);
 		}
 
+#if SFML_VERSION_MAJOR < 2
 		if (!m_window.SetActive())
+#else
+		if (!m_window.setActive())
+#endif
 			puts("Can't activate window !");
 
 		glViewport(0, 0, 240*4, 160*4);
@@ -227,13 +256,21 @@ namespace mym
 
 			glDrawArrays(GL_QUADS, 0, 4);
 
+#if SFML_VERSION_MAJOR < 2
 			m_window.Display();
+#else
+			m_window.display();
+#endif
 		}
 
 		glDisableClientState(GL_VERTEX_ARRAY);
 		glDisableClientState(GL_TEXTURE_COORD_ARRAY);
 
+#if SFML_VERSION_MAJOR < 2
 		m_window.SetActive(false);
+#else
+		m_window.setActive(false);
+#endif
 		pthread_mutex_unlock(&m_mutex);
 	}
 }


### PR DESCRIPTION
Newer versions of SFML use a different camelCase convention from the OriginalLibrary. This patch ensures meteor will compile against both.
