### PR TITLE
Report git version with library_version

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -41,6 +41,10 @@ else ifneq ($(findstring MINGW,$(shell uname -a)),)
 endif
 
 TARGET_NAME := meteor
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 ifeq ($(platform), unix)
    TARGET := $(TARGET_NAME)_libretro.so

--- a/libretro/jni/Android.mk
+++ b/libretro/jni/Android.mk
@@ -2,6 +2,11 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 ifeq ($(TARGET_ARCH),arm)
 LOCAL_CFLAGS += -DANDROID_ARM
 LOCAL_ARM_MODE := arm

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -52,7 +52,10 @@ void retro_set_controller_port_device(unsigned, unsigned) {}
 void retro_get_system_info(struct retro_system_info *info)
 {
 	info->library_name = "Meteor GBA";
-	info->library_version = "v1.4";
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+	info->library_version = "v1.4" GIT_VERSION;
 	info->need_fullpath = false;
 	info->block_extract = false;
 	info->valid_extensions = "gba";


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.