### PR TITLE
Report git version with library_version on Android

### DIFF
--- a/libretro/jni/Android.mk
+++ b/libretro/jni/Android.mk
@@ -29,7 +29,7 @@ include $(LIBRETRO_DIR)/Makefile.common
 
 LOCAL_MODULE    := libretro
 LOCAL_SRC_FILES = $(SOURCES_CXX)
-LOCAL_CXXFLAGS = -DINLINE=inline -DLSB_FIRST -D__LIBRETRO__ -DFRONTEND_SUPPORTS_RGB565 -I$(CORE_DIR)/ameteor/include
+LOCAL_CXXFLAGS += -DINLINE=inline -DLSB_FIRST -D__LIBRETRO__ -DFRONTEND_SUPPORTS_RGB565 -I$(CORE_DIR)/ameteor/include
 LOCAL_C_INCLUDES += external/stlport/stlport bionic $(CORE_DIR)/ameteor/include
 
 # https://code.google.com/p/android-ndk-profiler/


### PR DESCRIPTION
This patch fixes GIT_VERSION on Android, which was missing due to bugs in Android.mk. Important for netplay between Android and non-Android systems.